### PR TITLE
fix VACUUM to not be called within a transaction

### DIFF
--- a/minidb.py
+++ b/minidb.py
@@ -167,6 +167,7 @@ class Store(object):
 
     def close(self):
         with self.lock:
+            self.db.isolation_level = None
             self._execute('VACUUM')
             self.db.close()
 


### PR DESCRIPTION
setting isolation level to autocommit just for the VACUUM call
before closing the connection.
This resolves a regression as VACUUM may not be performed
within a transaction as the transaction block was opened
implicitly and auto-commit has been removed in python 3.6.
https://bugs.python.org/issue28518