### PR TITLE
Fix None comparisons

### DIFF
--- a/minidb.py
+++ b/minidb.py
@@ -141,7 +141,7 @@ class Store(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if (exc_type, exc_value, traceback) is (None, None, None):
+        if exc_type is exc_value is traceback is None:
             self.commit()
 
         self.close()


### PR DESCRIPTION
Fixes:

    minidb.py:144: SyntaxWarning: "is" with a literal. Did you mean "=="?

with Python 3.8.