### PR TITLE
Switch from the distutils to setuptools

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: python -m pip install --upgrade pip
-      - run: python -m pip install flake8 pytest
+      - run: python -m pip install flake8 pytest build
       - run: python -m pytest -v
       - run: flake8 .
-      - run: python setup.py sdist
+      - run: python -m build --sdist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,6 +18,8 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - uses: actions/checkout@v2
       - run: python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 import os
 import re
-from distutils.core import setup
+from setuptools import setup
 
 dirname = os.path.dirname(os.path.abspath(__file__))
 src = open(os.path.join(dirname, '{}.py'.format(__doc__))).read()


### PR DESCRIPTION
The distutils modules has been removed in python 3.12 so minidb can't be built on a fresh 3.12 installation.

This MR switch from `distutils` package to `setuptools` which provides the same API.

More info :
* [Python 3.12 changelog with deprecation notice](https://docs.python.org/3/whatsnew/3.12.html)
* [Setuptools doc on migration](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html)