### PR TITLE
Update github action to setup python

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,7 +21,13 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
       - run: python -m pip install --upgrade pip
       - run: python -m pip install flake8 pytest
       - run: python -m pytest -v


### PR DESCRIPTION
Add the setup python step to configure the right python version for running the tests.

At the moment, the tests all just run with the python version in the ubuntu image, which is 3.10.